### PR TITLE
Updated ServiceProvider name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ composer require fruitcake/laravel-weasyprint
 You can publish the config file:
 
 ```bash
-php artisan vendor:publish --provider="Fruitcake\WeasyPrint\ServiceProvider"
+php artisan vendor:publish --provider="Fruitcake\WeasyPrint\WeasyPrintProvider"
 ```
 
 ### Usage


### PR DESCRIPTION
Before:
```
php artisan vendor:publish --provider="Fruitcake\WeasyPrint\ServiceProvider"

   INFO  No publishable resources for tag [].  
```

After:
```
php artisan vendor:publish --provider="Fruitcake\WeasyPrint\WeasyPrintProvider"

   INFO  Publishing assets.  

  Copying file [vendor/fruitcake/laravel-weasyprint/config/weasyprint.php] to [config/weasyprint.php] ......................................... DONE

```